### PR TITLE
add node version 20.x into ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x ]
+        node-version: [ 16.x, 18.x, 20.x ]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## 対応内容
- chore: add node version 20.x ( 90e8f43 )